### PR TITLE
fix: フレーバーのブランド混在時のセッション作成エラーと重複メッセージを修正

### DIFF
--- a/backend/internal/models/session_insert.go
+++ b/backend/internal/models/session_insert.go
@@ -20,8 +20,8 @@ type SessionInsert struct {
 type FlavorInsert struct {
 	ID          string  `json:"id"`
 	SessionID   string  `json:"session_id"`
-	FlavorName  *string `json:"flavor_name,omitempty"`
-	Brand       *string `json:"brand,omitempty"`
+	FlavorName  *string `json:"flavor_name"`
+	Brand       *string `json:"brand"`
 	FlavorOrder int     `json:"flavor_order"`
 	// Explicitly exclude created_at
 }

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -209,9 +209,6 @@ export const Sessions: React.FC = () => {
                     <span className="text-gray-600 text-sm">読み込み中...</span>
                   </div>
                 )}
-                {!hasMore && (
-                  <p className="text-gray-500 text-sm">すべてのセッションを表示しました</p>
-                )}
               </div>
             )}
           </div>
@@ -298,9 +295,9 @@ export const Sessions: React.FC = () => {
             </table>
           </div>
 
-          {/* Infinite scroll loading indicator */}
+          {/* Infinite scroll loading indicator - Desktop only */}
           {sessions.length > 0 && (
-            <div ref={loadMoreRef} className="mt-8 text-center py-4">
+            <div ref={loadMoreRef} className="hidden sm:block mt-8 text-center py-4">
               {loadingMore && (
                 <div className="inline-flex items-center">
                   <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -309,9 +306,6 @@ export const Sessions: React.FC = () => {
                   </svg>
                   <span className="text-gray-600">読み込み中...</span>
                 </div>
-              )}
-              {!hasMore && sessions.length > 0 && (
-                <p className="text-gray-500 text-sm">すべてのセッションを表示しました</p>
               )}
             </div>
           )}


### PR DESCRIPTION
## 概要
- セッション作成時、ブランド情報有り・無しのフレーバーが混在すると失敗する問題を修正
- 「すべてのセッションを表示しました」メッセージの重複表示を解消
- 不要な完了メッセージを削除

## 修正内容

### 1. フレーバーのブランド混在問題の修正
- `FlavorInsert`モデルから`omitempty`タグを削除
- これにより、`nil`値でも一貫したJSON形式でSupabaseに送信されるように

### 2. UIの改善
- モバイル・デスクトップ両方で表示されていた重複メッセージを修正
- ユーザーリクエストに基づき、「すべてのセッションを表示しました」メッセージ自体を削除

## テスト内容
- [x] TypeScriptの型チェック成功
- [x] フロントエンドのビルド成功
- [x] 本番環境へのデプロイ完了
- [x] APIエンドポイントの動作確認

## デプロイ状況
- フロントエンド: https://shisha.toof.jp (デプロイ済み)
- バックエンド: https://api.shisha.toof.jp/v1 (インフラ更新済み)

🤖 Generated with [Claude Code](https://claude.ai/code)