### PR TITLE
fix: モバイルでの円グラフと凡例の間隔を改善

### DIFF
--- a/frontend/src/components/StatisticsChart.tsx
+++ b/frontend/src/components/StatisticsChart.tsx
@@ -61,7 +61,10 @@ export const StatisticsChart: React.FC<StatisticsChartProps> = ({
     maintainAspectRatio: false,
     layout: {
       padding: {
+        top: 10,
         bottom: 10,
+        left: 10,
+        right: 10,
       },
     },
     plugins: {
@@ -71,12 +74,12 @@ export const StatisticsChart: React.FC<StatisticsChartProps> = ({
         fullSize: true,
         align: 'center' as const,
         labels: {
-          padding: 10,
+          padding: 8,
           font: {
-            size: 12,
+            size: 11,
           },
-          boxWidth: 12,
-          boxHeight: 12,
+          boxWidth: 10,
+          boxHeight: 10,
           usePointStyle: true,
         },
       },
@@ -100,7 +103,7 @@ export const StatisticsChart: React.FC<StatisticsChartProps> = ({
       {data.length === 0 ? (
         <p className="text-gray-500 text-sm">データがありません</p>
       ) : (
-        <div className="w-full" style={{ minHeight: `${Math.max(400, data.length * 30 + 300)}px` }}>
+        <div className="w-full h-64 sm:h-80 md:h-96">
           <Pie data={chartData} options={options} />
         </div>
       )}


### PR DESCRIPTION
## 概要
スマートフォンで円グラフと凡例の間に過剰な空白が表示される問題を修正しました。

## 修正内容

### 1. レスポンシブな固定高さの採用
動的な高さ計算 `Math.max(400, data.length * 30 + 300)px` を削除し、画面サイズに応じた固定高さに変更：
- モバイル: `h-64` (256px)
- タブレット: `h-80` (320px)  
- デスクトップ: `h-96` (384px)

### 2. 凡例の最適化
モバイル表示を改善するため、凡例の各種サイズを調整：
- パディング: 10 → 8
- フォントサイズ: 12 → 11
- ボックスサイズ: 12×12 → 10×10

### 3. チャートレイアウトの統一
全体のパディングを統一して視覚的なバランスを改善

## 確認事項
- [x] TypeScriptの型チェック成功
- [x] レスポンシブデザインの動作確認
- [x] 各画面サイズでの表示確認

## スクリーンショット
修正前: データ数に応じて高さが大きく変動し、特にモバイルで過剰な空白が発生
修正後: 画面サイズに応じた適切な固定高さで、一貫した表示

🤖 Generated with [Claude Code](https://claude.ai/code)