### PR TITLE
feat: add order statistics chart

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -151,6 +151,9 @@ func main() {
 	protected.GET("/stores/stats", sessionHandler.GetStoreStats)
 	protected.GET("/creators/stats", sessionHandler.GetCreatorStats)
 
+	// Order statistics route
+	protected.GET("/orders/stats", sessionHandler.GetOrderStats)
+
 	// Start server
 	log.Printf("Server starting on port %s", cfg.Port)
 	if err := e.Start(":" + cfg.Port); err != nil {

--- a/backend/internal/api/session_handler.go
+++ b/backend/internal/api/session_handler.go
@@ -407,3 +407,24 @@ func (h *SessionHandler) GetCreatorStats(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, stats)
 }
+
+// GetOrderStats godoc
+// @Summary Get order statistics
+// @Description Get order statistics for the authenticated user
+// @Tags statistics
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} models.OrderStats "Order statistics"
+// @Failure 500 {object} object{error=string} "Failed to get order statistics"
+// @Router /orders/stats [get]
+func (h *SessionHandler) GetOrderStats(c echo.Context) error {
+	userID := c.Get("user_id").(string)
+
+	stats, err := h.repo.GetOrderStats(c.Request().Context(), userID)
+	if err != nil {
+		log.Printf("GetOrderStats error for user %s: %v", userID, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to get order statistics"})
+	}
+
+	return c.JSON(http.StatusOK, stats)
+}

--- a/backend/internal/models/session.go
+++ b/backend/internal/models/session.go
@@ -74,3 +74,12 @@ type StoreStats struct {
 type CreatorStats struct {
 	Creators []CreatorCount `json:"creators"`
 }
+
+type OrderCount struct {
+	OrderDetails string `json:"order_details"`
+	Count        int    `json:"count"`
+}
+
+type OrderStats struct {
+	Orders []OrderCount `json:"orders"`
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -12,7 +12,8 @@ import type {
   CalendarData,
   SessionsByDateResponse,
   StoreStats,
-  CreatorStats
+  CreatorStats,
+  OrderStats
 } from '../types/api';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/v1';
@@ -173,6 +174,11 @@ class ApiClient {
 
   async getCreatorStats(): Promise<CreatorStats> {
     const response = await this.api.get<CreatorStats>('/creators/stats');
+    return response.data;
+  }
+
+  async getOrderStats(): Promise<OrderStats> {
+    const response = await this.api.get<OrderStats>('/orders/stats');
     return response.data;
   }
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -100,6 +100,16 @@ export interface StoreStats {
   stores: StoreCount[];
 }
 
+
 export interface CreatorStats {
   creators: CreatorCount[];
+}
+
+export interface OrderCount {
+  order_details: string;
+  count: number;
+}
+
+export interface OrderStats {
+  orders: OrderCount[];
 }


### PR DESCRIPTION
Adds a new tab to the dashboard to display a pie chart and ranking of order statistics.

Co-authored-by: Gemini <gemini-generated-commit@google.com>