### PR TITLE
fix: セッション一覧画面の横スクロール問題を修正

### DIFF
--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -230,7 +230,7 @@ export const Sessions: React.FC = () => {
                     店舗
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    ミックス
+                    ミックス名
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     作成者

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -219,7 +219,7 @@ export const Sessions: React.FC = () => {
           </div>
 
           {/* Desktop view - Table */}
-          <div className="hidden sm:block mt-8 overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+          <div className="hidden sm:block mt-8 overflow-x-auto shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
             <table className="min-w-full divide-y divide-gray-300">
               <thead className="bg-gray-50">
                 <tr>


### PR DESCRIPTION
## Summary
- セッション一覧画面のテーブルが画面幅が狭い時に横スクロール可能になるように修正

## 問題
- 画面幅が狭い時、テーブルの右側（アクションボタン）が見えなくなり、ユーザーが削除などの操作ができない

## 修正内容
- テーブルコンテナの`overflow-hidden`を`overflow-x-auto`に変更
- 横スクロールバーでテーブル全体を表示できるように改善

## Test plan
- [ ] セッション一覧画面で画面幅を狭くする
- [ ] 横スクロールバーが表示されることを確認
- [ ] スクロールして削除ボタンなどのアクションボタンにアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)